### PR TITLE
Fix GitHub Actions build workflow

### DIFF
--- a/.github/workflows/python-app-build.yml
+++ b/.github/workflows/python-app-build.yml
@@ -71,13 +71,13 @@ jobs:
       run: |
         uv sync --extra dev
     - name: Install Windows dependencies
-      run: |
-        iwr -useb get.scoop.sh -outfile 'install.ps1'
-        .\install.ps1 -RunAsAdmin
-        scoop update
-        scoop bucket add extras
-        scoop install nsis
-      if: runner.os == 'Windows'
+      uses: MinoruSekine/setup-scoop@v4.0.2
+      with:
+        install_scoop: true
+        buckets: extras
+        apps: makensis
+        scoop_update: true
+        update_path: true
     - name: Build executable
       run: |
         uv run python -m PyInstaller src/Wordweaver.spec


### PR DESCRIPTION
## Summary

- Add missing PyInstaller spec file (`src/Wordweaver.spec`) that the build workflow was referencing
- Update workflow to use correct spec file path
- Replace manual Scoop installation script with `MinoruSekine/setup-scoop@v4.0.2` action for cleaner Windows builds
- Upgrade to Python 3.13 and update GitHub Actions (checkout@v6, upload-artifact@v6)

## Test plan

- [ ] Verify the build workflow completes successfully on Ubuntu
- [ ] Verify the build workflow completes successfully on macOS
- [ ] Verify the build workflow completes successfully on Windows