### PR TITLE
Fix Scoop package name: use nsis instead of makensis

### DIFF
--- a/.github/workflows/python-app-build.yml
+++ b/.github/workflows/python-app-build.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         install_scoop: true
         buckets: extras
-        apps: makensis
+        apps: nsis
         scoop_update: true
         update_path: true
     - name: Build executable


### PR DESCRIPTION
The package name is 'nsis', which provides the 'makensis' executable.