### PR TITLE
Bugfix/add pyinstaller spec

### DIFF
--- a/src/Wordweaver.spec
+++ b/src/Wordweaver.spec
@@ -41,35 +41,61 @@ a = Analysis(
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
-exe = EXE(
-    pyz,
-    a.scripts,
-    [],
-    exclude_binaries=True,
-    name='Wordweaver',
-    debug=False,
-    bootloader_ignore_signals=False,
-    strip=False,
-    upx=True,
-    console=False,
-    disable_windowed_traceback=False,
-    argv_emulation=False,
-    target_arch=None,
-    codesign_identity=None,
-    entitlements_file=None,
-    icon=icon_file,
-)
+# Windows: single-file executable for NSIS installer
+# macOS/Linux: folder-based for app bundle
+if sys.platform == 'win32':
+    exe = EXE(
+        pyz,
+        a.scripts,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        [],
+        name='Wordweaver',
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        runtime_tmpdir=None,
+        console=False,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+        icon=icon_file,
+    )
+else:
+    exe = EXE(
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        name='Wordweaver',
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        console=False,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+        icon=icon_file,
+    )
 
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    strip=False,
-    upx=True,
-    upx_exclude=[],
-    name='Wordweaver',
-)
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        name='Wordweaver',
+    )
 
 # macOS app bundle
 if sys.platform == 'darwin':

--- a/src/Wordweaver.spec
+++ b/src/Wordweaver.spec
@@ -41,61 +41,35 @@ a = Analysis(
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
-# Windows: single-file executable for NSIS installer
-# macOS/Linux: folder-based for app bundle
-if sys.platform == 'win32':
-    exe = EXE(
-        pyz,
-        a.scripts,
-        a.binaries,
-        a.zipfiles,
-        a.datas,
-        [],
-        name='Wordweaver',
-        debug=False,
-        bootloader_ignore_signals=False,
-        strip=False,
-        upx=True,
-        upx_exclude=[],
-        runtime_tmpdir=None,
-        console=False,
-        disable_windowed_traceback=False,
-        argv_emulation=False,
-        target_arch=None,
-        codesign_identity=None,
-        entitlements_file=None,
-        icon=icon_file,
-    )
-else:
-    exe = EXE(
-        pyz,
-        a.scripts,
-        [],
-        exclude_binaries=True,
-        name='Wordweaver',
-        debug=False,
-        bootloader_ignore_signals=False,
-        strip=False,
-        upx=True,
-        console=False,
-        disable_windowed_traceback=False,
-        argv_emulation=False,
-        target_arch=None,
-        codesign_identity=None,
-        entitlements_file=None,
-        icon=icon_file,
-    )
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='Wordweaver',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=icon_file,
+)
 
-    coll = COLLECT(
-        exe,
-        a.binaries,
-        a.zipfiles,
-        a.datas,
-        strip=False,
-        upx=True,
-        upx_exclude=[],
-        name='Wordweaver',
-    )
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='Wordweaver',
+)
 
 # macOS app bundle
 if sys.platform == 'darwin':

--- a/src/wordweaver.nsi
+++ b/src/wordweaver.nsi
@@ -5,7 +5,7 @@
 Name "Wordweaver"
 
 ; The file to write
-OutFile "..\dist\Wordweaver-install.exe"
+OutFile "dist\Wordweaver-install.exe"
 
 ; Request application privileges for Windows Vista and higher
 RequestExecutionLevel admin
@@ -42,7 +42,7 @@ Section "Wordweaver (required)"
   SetOutPath $INSTDIR
   
   ; Put file there
-  File "..\dist\Wordweaver.exe"
+  File "dist\Wordweaver.exe"
   
   ; Write the installation path into the registry
   WriteRegStr HKLM "SOFTWARE\Wordweaver" "Install_Dir" "$INSTDIR"

--- a/src/wordweaver.nsi
+++ b/src/wordweaver.nsi
@@ -42,7 +42,7 @@ Section "Wordweaver (required)"
   SetOutPath $INSTDIR
   
   ; Put file there
-  File "dist\Wordweaver.exe"
+  File "dist\Wordweaver\Wordweaver.exe"
   
   ; Write the installation path into the registry
   WriteRegStr HKLM "SOFTWARE\Wordweaver" "Install_Dir" "$INSTDIR"


### PR DESCRIPTION
This pull request makes small adjustments to the installer script for Wordweaver to update file paths for the output installer and the main executable.

- The output installer will now be placed in the `dist` directory instead of its parent.
- The path to the main executable in the installer section has been updated to reflect its location in the `dist\Wordweaver` subdirectory.